### PR TITLE
Fix gamepad support

### DIFF
--- a/Assets/Elder Futhark.prefab
+++ b/Assets/Elder Futhark.prefab
@@ -10126,7 +10126,7 @@ MonoBehaviour:
   Children:
   - {fileID: 114454569139615866}
   IsPassThrough: 0
-  ChildRowLength: 0
+  ChildRowLength: 8
   Highlight: {fileID: 114699847705179004}
   SelectableColliders: []
   DefaultSelectableIndex: 0

--- a/Assets/Elder Futhark.prefab
+++ b/Assets/Elder Futhark.prefab
@@ -10126,7 +10126,7 @@ MonoBehaviour:
   Children:
   - {fileID: 114454569139615866}
   IsPassThrough: 0
-  ChildRowLength: 8
+  ChildRowLength: 7
   Highlight: {fileID: 114699847705179004}
   SelectableColliders: []
   DefaultSelectableIndex: 0

--- a/Assets/TestHarness/TestHarness.cs
+++ b/Assets/TestHarness/TestHarness.cs
@@ -1467,7 +1467,11 @@ public class TestHarness : MonoBehaviour
 						currentSelectable.ActivateChildSelectableAreas();
 
 						if (select != null)
-							select.GetComponent<TestSelectable>().Select();
+						{
+							var selectTest = select.GetComponent<TestSelectable>();
+							selectTest.Select();
+							lastSelected = selectTest;
+						}
 					}
 
 				};


### PR DESCRIPTION
The TestHarness does not currently support gamepad emulation despite the option being visible. Testing support must be done in game.
The selectableLocations array contains the pattern the buttons are detected in based on the order of the Runes array. If you want to rearrange the button locations, you'll need to manually edit the selectableLocations array.
This is the best example I could use:
![image](https://user-images.githubusercontent.com/4911928/81484815-8e65a180-91fd-11ea-9768-6a9aa818ab45.png)
Key:
Thurisaz (22), empty, Fehu (5), Ansuz (0), empty, Raido (17), Eihwaz (10),
Hagalaz (7), empty, Ehwaz (4), Isa (8), Kenaz (2), Jera (9), Gebo (6),
Algiz (16), Teiwaz (19), empty, Dagaz (3), Berkana (1), empty, Laguz (11),
empty, Sowulo (18), Wunjo (21), Uruz (20), empty, Nauthiz (13), Perthro (15),
empty, empty, Othila (14), empty, empty, Mannaz (12), empty

The names do not matter, only the positions of their indices do.